### PR TITLE
ライブラリのバージョンを固定値指定にし、勝手に更新されないようにする

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -22,7 +22,10 @@ jobs:
       # You can specify other versions if desired, see documentation here:
       # https://github.com/dart-lang/setup-dart/blob/main/README.md
       # - uses: dart-lang/setup-dart@v1
-      - uses: dart-lang/setup-dart@9a04e6d73cca37bd455e0608d7e5092f881fd603
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: dart
+          version: '3.5.2'
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -24,8 +24,7 @@ jobs:
       # - uses: dart-lang/setup-dart@v1
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: dart
-          version: '3.5.2'
+          sdk: 3.5.2
 
       - name: Install dependencies
         run: dart pub get

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -225,5 +225,5 @@ packages:
     source: hosted
     version: "14.2.5"
 sdks:
-  dart: ">=3.4.3 <4.0.0"
+  dart: "3.5.2"
   flutter: ">=3.22.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.4.3 <4.0.0'
+  sdk: '3.5.2'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -34,8 +34,8 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.6
-  flame: ^1.22.0
+  cupertino_icons: 1.0.8
+  flame: 1.22.0
 
 dev_dependencies:
   flutter_test:
@@ -46,7 +46,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^3.0.0
+  flutter_lints: 3.0.2
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
今後、ライブラリ追加を行う際やpubspec.yaml を書き換えた際に意図せずライブラリのバージョンが更新されないように
ライブラリバージョンの固定を行いました。

今までは、固定化していないためその時の最新バージョンを利用するようになっていました。
